### PR TITLE
fix(): Delete goal if no IK can be found

### DIFF
--- a/src/HeadReference.cpp
+++ b/src/HeadReference.cpp
@@ -144,7 +144,12 @@ void HeadReference::generateReferences()
             tf::Stamped<tf::Point> tp;
             tf::pointStampedMsgToTF(goal.target_point,tp);
             tp.stamp_ = ros::Time();
-            targetToPanTilt(tp, goal.pan, goal.tilt);
+            if (!targetToPanTilt(tp, goal.pan, goal.tilt))
+            {
+              gh.setAborted();
+              goal_handles_.erase (goal_handles_.begin(), goal_handles_.begin()+1);
+              return;
+            }
             publishMarker(tp);
         }
 


### PR DESCRIPTION
When a goal was present in map frame and we kill the localization
(world_model). The head ref server was going nuts since it could not
perform an inververse kinematics from the map position to the pan / tilt
joint positions. This will make sure that if thist transformation goes
wrong, the goal will be removed.